### PR TITLE
feat!: consolidated parsing methods and made public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,16 @@ The format is based on [Keep a Changelog], and this project adheres to
   changed from `Option<&str>` to `Option<AllowedCpc<'_>>`. This should
   always have been the case; however, when adding this type for
   `StreamInf`, the `IFrameStreamInf` was forgotten about.
+- BREAKING CHANGE: `DecimalResolutionParseError` removed the
+  `MissingWidth` case, and renamed `MissingHeight` to `MissingSeparator`
+  to better indicate the source of the error (the `x` separator not
+  found).
+- BREAKING CHANGE: `PartByterange` was removed in favor of the new more
+  common type `DecimalIntegerRange` that is used for all types following
+  the same scheme (`<n>[@<o>]`). This allowed for the parsing to be
+  consolidated, and now, the `TryFrom<&str>` methods are public, so
+  users of the library do not have to reimplement the parsing if they
+  want to use the types directly with custom data.
 
 ## [0.6.0] - 2025-08-19
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -714,21 +714,18 @@ impl Error for UnrecognizedEnumerationError<'_> {}
 /// An error found when trying to parse a decimal resolution (`<width>x<height>`).
 #[derive(Debug, PartialEq, Clone, Copy)]
 pub enum DecimalResolutionParseError {
-    /// The width component was missing.
-    MissingWidth,
     /// The width component was not a valid integer.
     InvalidWidth,
-    /// The height component was missing.
-    MissingHeight,
+    /// The `x` separator character was missing.
+    MissingSeparator,
     /// The height component was not a valid integer.
     InvalidHeight,
 }
 impl Display for DecimalResolutionParseError {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::MissingWidth => write!(f, "missing width"),
             Self::InvalidWidth => write!(f, "not a number for width"),
-            Self::MissingHeight => write!(f, "missing height"),
+            Self::MissingSeparator => write!(f, "missing `x` separator"),
             Self::InvalidHeight => write!(f, "not a number for height"),
         }
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -682,6 +682,29 @@ impl Display for ParseDecimalIntegerRangeError {
 }
 impl Error for ParseDecimalIntegerRangeError {}
 
+/// An error when trying to parse the `EXT-X-MAP:BYTERANGE` attribute.
+#[derive(Debug, PartialEq, Clone, Copy)]
+pub enum ParseMapByterangeError {
+    /// An error parsing the decimal integer range.
+    RangeParseError(ParseDecimalIntegerRangeError),
+    /// The offset component was missing but it is needed for `MapByterange`.
+    MissingOffset,
+}
+impl Display for ParseMapByterangeError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::RangeParseError(e) => e.fmt(f),
+            Self::MissingOffset => write!(f, "missing offset component"),
+        }
+    }
+}
+impl Error for ParseMapByterangeError {}
+impl From<ParseDecimalIntegerRangeError> for ParseMapByterangeError {
+    fn from(value: ParseDecimalIntegerRangeError) -> Self {
+        Self::RangeParseError(value)
+    }
+}
+
 /// An error found when trying to parse a float from a byte slice (`&[u8]`).
 #[derive(Debug, PartialEq, Clone, Copy)]
 pub struct ParseFloatError;

--- a/src/tag_internal/hls/byterange.rs
+++ b/src/tag_internal/hls/byterange.rs
@@ -28,13 +28,13 @@ impl<'a> TryFrom<UnknownTag<'a>> for Byterange<'a> {
     type Error = ValidationError;
 
     fn try_from(tag: UnknownTag<'a>) -> Result<Self, Self::Error> {
-        let (length, offset) = tag
+        let range = tag
             .value()
             .ok_or(ParseTagValueError::UnexpectedEmpty)?
             .try_as_decimal_integer_range()?;
         Ok(Self {
-            length,
-            offset,
+            length: range.length,
+            offset: range.offset,
             output_line: Cow::Borrowed(tag.original_input),
             output_line_is_dirty: false,
         })

--- a/src/tag_internal/hls/mod.rs
+++ b/src/tag_internal/hls/mod.rs
@@ -584,8 +584,8 @@ mod tests {
     use crate::{
         date_time,
         tag::{
-            DecimalResolution, HlsPlaylistType, TagValue,
-            hls::{daterange::ExtensionAttributeValue, map::MapByterange, part::PartByterange},
+            DecimalIntegerRange, DecimalResolution, HlsPlaylistType, TagValue,
+            hls::{daterange::ExtensionAttributeValue, map::MapByterange},
         },
     };
     use pretty_assertions::assert_eq;
@@ -877,7 +877,7 @@ mod tests {
                     .with_uri("part.1.mp4")
                     .with_duration(0.5)
                     .with_independent()
-                    .with_byterange(PartByterange {
+                    .with_byterange(DecimalIntegerRange {
                         length: 1024,
                         offset: Some(512)
                     })
@@ -894,7 +894,7 @@ mod tests {
                 Part::builder()
                     .with_uri("part.1.mp4")
                     .with_duration(0.5)
-                    .with_byterange(PartByterange {
+                    .with_byterange(DecimalIntegerRange {
                         length: 1024,
                         offset: None
                     })


### PR DESCRIPTION
Some types had duplicated parsing based on where they were found (`DecimalResolution`, `MapByterange`, `PartByterange`, `TagValue::try_as_decimal_integer_range`). The parsing for `MapByterange` was made public, as well as a new type that replaces `PartByterange`: `DecimalIntegerRange`.

Fixes #9 